### PR TITLE
twitch-emotes

### DIFF
--- a/twitchpopups.htm
+++ b/twitchpopups.htm
@@ -16,6 +16,9 @@
         // The emoji that surrounds the hotseat messages.
         const hotseatEmoji = '🔥';
 
+        // Allow twitch emotes, can be true or false.
+        const twitchEmotes = true;
+
         // Follow the instructions in README.md
         
     </script>
@@ -36,6 +39,11 @@
 			margin: 0;
 			margin-left: 15px;
 			white-space: nowrap;
+		}
+
+		#popuptext img{
+				width: 70px;
+				margin-bottom: -11px;
 		}
 
 		#popupbox {
@@ -99,7 +107,7 @@
                 if (commandName.startsWith("!alert ")) {
                     $("#popupbox").show();
                     $("#popupbox").css({"background-color":alertBg}); 
-                    $("#popuptext").text(commandName.substr(7).toUpperCase());
+                    $("#popuptext").html(formatEmotes(commandName, context.emotes,true).substr(7));
                     doAnimation();
                 } else if (commandName.startsWith("!delete")) {
                   deleteAnimation();
@@ -116,7 +124,7 @@
             if (hotSeatIsOn) {
                 // Ignore messages that are not from "hotSeatUser" and include mentions to users that are not the streamer at the start of the message
                 if (context.username === hotSeatUser && (!commandName.startsWith('@') || commandName.startsWith('@' + twitchChannel))) {
-                    $("#popuptext").text(`${hotseatEmoji} ${context['display-name']}: ${commandName} ${hotseatEmoji}`);
+                    $("#popuptext").html(`${hotseatEmoji} ${context['display-name']}: ${formatEmotes(commandName, context.emotes,false)} ${hotseatEmoji}`);
                     doHotseatAnimation();
                 }
             }
@@ -149,6 +157,34 @@
         $("#popuptext").animate({"opacity":0, "margin-left":"50px"}, 700);
     }
     
+    const formatEmotes = (message, emotes, upperCase) => {
+        //parse the message for html and remove any tags
+      if(upperCase){
+        message = message.toUpperCase();
+      }
+      
+      let newMessage = $($.parseHTML(message)).text().split("");
+
+      //replace any twitch emotes in the message with img tags for those emotes
+      if(twitchEmotes){
+        for (let emoteIndex in emotes) {
+          const emote = emotes[emoteIndex];
+          for (let charIndexes in emote) {
+            let emoteIndexes = emote[charIndexes];
+            if (typeof emoteIndexes == "string") {
+              emoteIndexes = emoteIndexes.split("-");
+              emoteIndexes = [parseInt(emoteIndexes[0]), parseInt(emoteIndexes[1])];
+              for (let i = emoteIndexes[0]; i <= emoteIndexes[1]; ++i) {
+                newMessage[i] = "";
+              }
+              newMessage[emoteIndexes[0]] = `<img class="emoticon" src="https://static-cdn.jtvnw.net/emoticons/v1/${emoteIndex}/3.0"/>`;
+            }
+          }
+        }
+      }
+      
+      return newMessage.join("");
+    }
 
     function onConnectedHandler (addr, port) {
         console.log(`* Connected to ${addr}:${port}`);

--- a/twitchpopups.htm
+++ b/twitchpopups.htm
@@ -43,7 +43,7 @@
 
 		#popuptext img{
 				width: 70px;
-				margin-bottom: -11px;
+				margin-bottom: -12px;
 		}
 
 		#popupbox {

--- a/twitchpopups.htm
+++ b/twitchpopups.htm
@@ -5,7 +5,7 @@
     <script type="text/javascript">
 
         // Change Limmy to your Twitch channel
-        const twitchChannel = 'Limmy';
+        const twitchChannel = 'Gantee';
 
         // Your alert background. Default is a vibrant green
         const alertBg = '#00AA00';
@@ -42,8 +42,10 @@
 		}
 
 		#popuptext img{
-				width: 70px;
-				margin-bottom: -12px;
+			width: 70px;
+			margin-bottom: -12px;
+			margin-right: -7px;
+			margin-left: -8px;
 		}
 
 		#popupbox {

--- a/twitchpopups.htm
+++ b/twitchpopups.htm
@@ -5,7 +5,7 @@
     <script type="text/javascript">
 
         // Change Limmy to your Twitch channel
-        const twitchChannel = 'Gantee';
+        const twitchChannel = 'Limmy';
 
         // Your alert background. Default is a vibrant green
         const alertBg = '#00AA00';

--- a/twitchpopups.htm
+++ b/twitchpopups.htm
@@ -159,31 +159,31 @@
     
     const formatEmotes = (message, emotes, upperCase) => {
         //parse the message for html and remove any tags
-      if(upperCase){
-        message = message.toUpperCase();
-      }
-      
-      let newMessage = $($.parseHTML(message)).text().split("");
-
-      //replace any twitch emotes in the message with img tags for those emotes
-      if(twitchEmotes){
-        for (let emoteIndex in emotes) {
-          const emote = emotes[emoteIndex];
-          for (let charIndexes in emote) {
-            let emoteIndexes = emote[charIndexes];
-            if (typeof emoteIndexes == "string") {
-              emoteIndexes = emoteIndexes.split("-");
-              emoteIndexes = [parseInt(emoteIndexes[0]), parseInt(emoteIndexes[1])];
-              for (let i = emoteIndexes[0]; i <= emoteIndexes[1]; ++i) {
-                newMessage[i] = "";
-              }
-              newMessage[emoteIndexes[0]] = `<img class="emoticon" src="https://static-cdn.jtvnw.net/emoticons/v1/${emoteIndex}/3.0"/>`;
-            }
-          }
+        if(upperCase){
+            message = message.toUpperCase();
         }
-      }
-      
-      return newMessage.join("");
+        
+        let newMessage = $($.parseHTML(message)).text().split("");
+        
+        //replace any twitch emotes in the message with img tags for those emotes
+        if(twitchEmotes){
+            for (let emoteIndex in emotes) {
+                const emote = emotes[emoteIndex];
+                for (let charIndexes in emote) {
+                    let emoteIndexes = emote[charIndexes];
+                    if (typeof emoteIndexes == "string") {
+                        emoteIndexes = emoteIndexes.split("-");
+                        emoteIndexes = [parseInt(emoteIndexes[0]), parseInt(emoteIndexes[1])];
+                        for (let i = emoteIndexes[0]; i <= emoteIndexes[1]; ++i) {
+                            newMessage[i] = "";
+                        }
+                        newMessage[emoteIndexes[0]] = `<img class="emoticon" src="https://static-cdn.jtvnw.net/emoticons/v1/${emoteIndex}/3.0"/>`;
+                    }
+                }
+            }
+        }
+        
+        return newMessage.join("");
     }
 
     function onConnectedHandler (addr, port) {


### PR DESCRIPTION
This is a cleaner pull request than the previous one!  Should be easier to review.

Allow twitch emotes in the !alert and !hotseat messages, can be disabled by setting twitchEmotes to false.

![image](https://user-images.githubusercontent.com/18462104/82488622-1b4f0b80-9ad8-11ea-8473-00e1576629c6.png)

If you'd prefer for twitch emotes to be aligned just like emoji then the styles to do that would be
`#popuptext img {
    width: 69px;
    margin-bottom: -13px;
}`

![image](https://user-images.githubusercontent.com/18462104/82488905-a4fed900-9ad8-11ea-955a-dc46d76326a5.png)