### PR TITLE
Adds basic amazon command for prime gaming speech

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -30,6 +30,18 @@ actionHandlers['!delete'] = {
     }
 };
 
+// =======================================
+// Command: !amazon
+// Description: will display the standard amazon alert with no sound (as not to distract the old man)
+// =======================================
+actionHandlers['!amazon'] = {
+    security: (context, textContent) => {
+        return context.mod || (context["badges-raw"] != null && context["badges-raw"].startsWith("broadcaster"))
+    },
+    handle: (context, textContent) => {
+        popup.showText("imGlitch gaming.amazon.com imGlitch", alertBg);
+    }
+};
 
 // =======================================
 // Command: !spotlight


### PR DESCRIPTION
!amazon shortcut command for displaying the gaming.amazon.com alert. 

Overrides the sound setting to mute (as not to distract during), and includes `imGlitch` emotes. 

Tested locally, however, could not get the twitch emotes working correctly, not sure what Limmy's setup is for it to work correctly.

![image](https://user-images.githubusercontent.com/1050665/96589544-daecf700-12dc-11eb-8b11-81e75a56330d.png)

This one is for you, Kate.