### PR TITLE
Simple change to allow using gradients for popup backgrounds

### DIFF
--- a/src/popup-helper.js
+++ b/src/popup-helper.js
@@ -5,7 +5,7 @@ const popup = {
     showText: (text, bgColour) => {
         $("#popupbox").show();
         $("#popuptext").html(text);
-        $("#popupbox").css({ "background-color": bgColour });
+        $("#popupbox").css({ "background": bgColour });
         $("#popuptext").css({ "opacity": 0, "margin-left": "50px" });
 
         const textWidth = $("#popuptext").width();
@@ -14,7 +14,7 @@ const popup = {
         $("#popuptext").animate({ "opacity": 1, "margin-left": "15px" }, 700);
     },
     /**
-     * Removes popup from screen and resets state of all commands 
+     * Removes popup from screen and resets state of all commands
      */
     delete: () => {
         spotlightUser = ""; // TODO: Remove this


### PR DESCRIPTION
Changing code to use `background` in popup box styles rather than `background-color`, so you can use [gradients ](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) in the settings file.

For example setting:

```javascript
const alertBg = 'linear-gradient(#185a9d, #43cea2 )';
```

Will give you:

![Screen Shot 2020-11-03 at 17 12 57](https://user-images.githubusercontent.com/142065/98018402-65167e80-1df8-11eb-88cc-ba46bdcb3274.png)
