### PR TITLE
Add !mission overlay as a special case of !alert

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -4,6 +4,9 @@ const twitchChannel = 'Limmy';
 // Your alert background. Default is a vibrant green
 const alertBg = '#00AA00';
 
+// Special alert background for mission objectives. Default is a blazing pink with transparency
+const missionBg = 'rgba(230, 11, 124, 0.75)';
+
 // Spotlight background colour. Default is a deep, rich "gold"
 const spotlightBg = '#a66600';
 

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -11,7 +11,7 @@ actionHandlers['!alert'] = {
         popup.showText(formattedText, alertBg);
         if (playAlertSound){
             new Audio(alertSoundFile).play();
-        } 
+        }
     }
 };
 
@@ -27,6 +27,21 @@ actionHandlers['!delete'] = {
     handle: (context, textContent) => {
         popup.delete();
         // TODO : loop through objects calling its own state reset function
+    }
+};
+
+
+// =======================================
+// Command: !mission
+// Description: a clone of alert used to display game objectives
+// =======================================
+actionHandlers['!mission'] = {
+    security: (context, textContent) => {
+        return context.mod || (context["badges-raw"] != null && context["badges-raw"].startsWith("broadcaster"))
+    },
+    handle: (context, textContent) => {
+        const formattedText = popup.formatEmotes(textContent, context.emotes, true).substr(9);
+        popup.showText(`MISSION: ${formattedText}`, missionBg);
     }
 };
 


### PR DESCRIPTION
This _might be_ useful, but no bother if it's not wanted, I had fun trying it — `!mission` is just a special copy of `!alert` that would useful because:

- It'd make mods lives a wee bit easier (maybe this is not desirable) by them just having to type `!mission` instead of `!alert Mission:` 
- Because mission objectives are up onscreen more often, might be useful to make them slightly transparent so they're not obscuring the stream fully
- I dunno, why not.

Test:
<img width="1120" alt="Screenshot 2021-06-22 at 13 52 52" src="https://user-images.githubusercontent.com/986185/122928019-5b2e9500-d361-11eb-8b93-5ef3e98bb395.png">
